### PR TITLE
Add logic to allow role to succeed in --check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     state: file
     suffix: '.rpm'
   register: ius_tempfile
+  check_mode: no
 
 - name: Attempting to download package to temporary location
   tags: ius
@@ -36,6 +37,7 @@
     dest: "{{ ius_tempfile.path }}"
     force: yes
     url: "http://{{ ius_dist }}.iuscommunity.org/{{ ius_pkg }}.rpm"
+  check_mode: no
 
 - name: Ensure that the {{ ius_pkg }} package is installed
   tags: ius


### PR DESCRIPTION
I noticed that this role fails in `--check` because the temp file task is skipped causing the `ius_tempfile` variable not to register. In addition, since the download task was skipped, the yum task for ensuring that the package is installed would fail in `--check` mode.

I've added `check_mode: no` to the temp file and download resources, which should allow the role to succeed in `--check` mode without creating any significant changes to the system. (This would leave a temporary file behind, which may not be in the spirit of `--check`, but I believe this is better than failing.)