### PR TITLE
Ignore GPG key check errors in check mode (when file doesn't exist)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,7 @@
 - name: Ensure that the {{ ius_pkg }} package is installed
   tags: ius
   become: true
+  register: yum_package
   yum:
     disable_plugin: "{{ ius_disable_plugin|join(',') or omit }}"
     disablerepo: "{{ ius_disablerepo|join(',') or omit }}"
@@ -78,6 +79,7 @@
   rpm_key:
     key: "{{ ius_rpm_key }}"
     state: present
+  ignore_errors: "{{ ansible_check_mode and yum_package.changed }}"
 
 - name: Ensure that the required ius packages are installed
   tags: ius


### PR DESCRIPTION
I noticed that the task `Ensure that the ius gpg keys are installed` will fail in `--check` mode when the key file doesn't yet exist on the filesystem (due to the release package not yet being installed).

Adding this condition means that when it's in check mode and the yum package task has changed the errors will be ignored. If the yum task is changed we can assume the package will be installed on a real (not check) run and the file will be present, so I think it's safe to ignore errors in that scenario.

If there's a better way to avoid errors in `--check` on this task, I'm open to suggestions.