### PR TITLE
Make tempfile tasks never considered changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     state: file
     suffix: '.rpm'
   register: ius_tempfile
+  changed_when: false
   check_mode: no
 
 - name: Attempting to download package to temporary location
@@ -37,6 +38,7 @@
     dest: "{{ ius_tempfile.path }}"
     force: yes
     url: "http://{{ ius_dist }}.iuscommunity.org/{{ ius_pkg }}.rpm"
+  changed_when: false
   check_mode: no
 
 - name: Ensure that the {{ ius_pkg }} package is installed
@@ -56,6 +58,7 @@
   file:
     path: "{{ ius_tempfile.path }}"
     state: absent
+  changed_when: false
 
 - name: Attempting to overlay ius repository configurations
   tags: ius


### PR DESCRIPTION
Although tempfile creations/modifications/deletions are a change to the
machine state, they are not very meaningful and don't need to be
reported as changed.

Resolves #6.