### PR TITLE
Disable gpg check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Available variables are listed below, along with default values:
     ius_enablerepo: []
     ius_packages: []
     ius_pkg: ius-release
+    ius_pkg_disable_gpgcheck: false
     ius_rel: "{{ ansible_distribution_major_version }}"
     ius_repository_ius: false
     ius_repository_ius_gpgcheck: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ ius_enable_plugin: []
 ius_enablerepo: []
 ius_packages: []
 ius_pkg: ius-release
+ius_pkg_disable_gpgcheck: false
 ius_rel: "{{ ansible_distribution_major_version }}"
 ius_repository_ius: false
 ius_repository_ius_gpgcheck: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,7 @@
       yum:
         name: "{{ ius_tempfile.path }}"
         state: present
+        disable_gpg_check: "{{ ius_pkg_disable_gpgcheck }}"
 
     - name: Attempting to purge temporary package from the filesystem
       tags: ius


### PR DESCRIPTION
Allow the role to work in environments unable to verify the GPG on the downloaded temp RPM.  Defaults to `false` to ensure current behavior is maintained.

Enabling this and setting `ius_rel: 7` appears to be sufficient to allow this role to work on Amazon Linux 2.